### PR TITLE
Test pair.value for null first

### DIFF
--- a/fingerprint2.js
+++ b/fingerprint2.js
@@ -108,7 +108,7 @@
         var values = [];
         newKeys.forEach(function(pair) {
           var value = pair.value;
-          if (typeof pair.value.join !== "undefined") {
+          if (pair.value && typeof pair.value.join !== "undefined") {
             value = pair.value.join(";");
           }
           values.push(value);


### PR DESCRIPTION
In IE10, pair.value is null in certain instance.  Evaluating pair.value.join results in a undefined value error in IE10.
